### PR TITLE
Add feature for SSH publickeys as recipients; improve tests and docs

### DIFF
--- a/LICENSE-apache
+++ b/LICENSE-apache
@@ -175,18 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Steve Schoettler
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-mit
+++ b/LICENSE-mit
@@ -1,6 +1,6 @@
 MIT License
 
-© Copyright 2023 Project Author. All rights reserved.
+© Copyright 2025 Steve Schoettler. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -24,19 +24,25 @@ age-op [ -h | --help ]
 
 ### Encrypt 
 
-Encrypt a file
+Encrypt a file using an identity (private key):
 
 ```shell
-age-op -e -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ FILE ]
+age-op -e -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ -a ] [ FILE ]
+```
+
+Encrypt a file using a recipient (public key) - useful for SSH public keys:
+
+```shell
+age-op -r -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ -a ] [ FILE ]
 ```
   
-Encrypt multiple files and folders.
+Encrypt multiple files and folders:
 
 ```shell
 tar czf - FILE_OR_DIR [ FILE_OR_DIR ... ] | age-op -e -k KEY_PATH -o foo.tar.gz.age
 ```
 
-Encrypt database backup
+Encrypt database backup:
 
 ```shell
 pg_dump | age-op -e -k KEY_PATH -o db-snapshot-$(date '+%Y%m%d-%H%M%S').age 
@@ -44,13 +50,13 @@ pg_dump | age-op -e -k KEY_PATH -o db-snapshot-$(date '+%Y%m%d-%H%M%S').age
 
 ### Decrypt
 
-Decrypt a file
+Decrypt a file:
 
 ```shell
 age-op -d -k KEY_PATH [ -o OUTPUT ] [-t TMPDIR ] [ FILE ]
 ```
   
-Decrypt files and folders.
+Decrypt files and folders:
 
 ```shell
 age-op -d -k KEY_PATH foo.tar.gz.age | tar xzf -
@@ -68,10 +74,16 @@ age-op -n -k KEY_PATH
 
 |             | description                                                                                                                                                                                                                                                              |
 |:------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -e          | Encrypt using identity (private key)                                                                                                                                                                                                                                     |
+| -r          | Encrypt using recipient (public key) - works with SSH public keys                                                                                                                                                                                                        |
+| -d          | Decrypt file using identity key                                                                                                                                                                                                                                          |
+| -n          | Generate new identity key                                                                                                                                                                                                                                                |
+| -a          | Use ASCII armor (PEM format) for encryption output                                                                                                                                                                                                                       |
 | -k KEY_PATH | (required) path to key in a 1Password vault, in one of the following formats:<br/>`op://vault/title`<br/>`op://vault/title/field`<br/>`op://vault/title/section/field`<br/>The first variant can be used when the field name is `password`.                              |
 | -o OUTPUT   | path to output file. If `-` or if not specified, stdout is used                                                                                                                                                                                                          |
 | -t TMPDIR   | TMPDIR is a private folder where keys are briefly stored so they can be read by `age`, then quickly removed.<br/>On linux, the default is `/run/user/USERID`. On macos, the default is `$TMPDIR`. Both of these folders are usually owned by current user with mode 700. |
 | FILE        | path to input file. If `-` or if not specified, stdin is used.                                                                                                                                                                                                           |
+| -h          | Show help and usage information                                                                                                                                                                                                                                          |
 
 
 ## 1Password access: local and remote

--- a/README.md
+++ b/README.md
@@ -171,3 +171,23 @@ All files created or read by `age-op` are 100% compatible with `age` and `rage`,
 ## Future
 
 There may be [reasons](https://github.com/stevelr/age-op/issues/1) for building this as an age plugin, or for taking advantage of future plugins. 
+
+
+## Testing
+
+A test script is included to verify functionality:
+
+```shell
+./test-age-op.sh
+```
+
+⚠️ **Warning**: The test script creates and deletes items in a vault named `ageop_testing_scratch_vault`. Use a different vault with:
+
+```shell
+TEST_VAULT=my_test_vault ./test-age-op.sh
+```
+
+Test with rage instead of age:
+```shell
+AGE=rage ./test-age-op.sh
+```

--- a/age-op
+++ b/age-op
@@ -183,7 +183,7 @@ fi
 
 [[ $1 =~ $help_regex ]] && _help
 
-while getopts ':hnredo:k:t:' OPTION; do
+while getopts ':hnredao:k:t:' OPTION; do
   case $OPTION in
     h) _help
         ;;

--- a/age-op
+++ b/age-op
@@ -48,6 +48,24 @@ _help() {
 
 age encryption with secret keys in 1password vault
 
+Usage:
+   $prog -e -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ -a ] [ FILE ]
+   $prog -r -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ -a ] [ FILE ]
+   $prog -d -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ FILE ]
+   $prog -n -k KEY_PATH
+   $prog -h
+
+Options:
+   -e            Encrypt using identity (private key)
+   -r            Encrypt using recipient (public key)
+   -d            Decrypt
+   -n            Generate new key
+   -k KEY_PATH   1Password key path
+   -o OUTPUT     Output file (default: stdout)
+   -t TMPDIR     Temporary directory (default: $tmppath)
+   -a            Use ASCII armor (PEM format)
+   -h            Show help
+
 Examples:
 
    Encrypt file:

--- a/age-op
+++ b/age-op
@@ -14,6 +14,13 @@
 AGE=${AGE:-$(which age)}
 OP=${OP:-op}
 
+# Ensure proper cleanup of temporary files, even on unexpected exit
+cleanup() {
+  if [ -n "$secret" ] && [ -f "$secret" ]; then
+    rm -f "$secret"
+  fi
+}
+trap cleanup EXIT INT TERM
 
 # Select private folder for temporary secrets. can be overridden with `-t` flag
 # The defaults for linux and macos are readable by owner only

--- a/age-op
+++ b/age-op
@@ -69,12 +69,12 @@ Options:
 Examples:
 
    Encrypt file:
-       $prog -e -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ FILE ]
+       $prog -e -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ -a ] [ FILE ]
            encrypt a single input file FILE using a private key.
            If FILE is '-' or not specified, stdin is encrypted
            If OUTPUT is '-' or not specified, the output is sent to stdout
 
-       $prog -r -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ FILE ]
+       $prog -r -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ -a ] [ FILE ]
            encrypt a single input file FILE using a public key (as recipient).
            Works with SSH public keys in 'authorized_keys' format.
            If FILE is '-' or not specified, stdin is encrypted
@@ -157,7 +157,8 @@ input=""
 output=""
 keypath=""
 stdin=0
-_err=""
+use_armor=""
+secret=""
 # putting this in a variable makes it work with zsh
 help_regex="^\-h|^--help|^help$"
 
@@ -181,6 +182,8 @@ while getopts ':hnredo:k:t:' OPTION; do
         ;;
     d) [ -n "$cmd" ] && _help "Only one of -e, -d, -r, or -n may be used"
         cmd="decrypt"
+        ;;
+    a) use_armor="--armor"
         ;;
     o) output=$OPTARG
         ;;
@@ -230,6 +233,11 @@ else
     _help "Invalid keypath '$keypath'"
   fi
   
+  # Prepare age command options
+  age_opts=""
+  [ -n "$use_armor" ] && age_opts="$age_opts $use_armor"
+  
+  # Execute appropriate age command based on the operation
   if [ "$cmd" = "recipient" ]; then
     # For recipient encryption with SSH public key, use -r flag directly
     if [ $stdin -eq 1 ]; then

--- a/age-op
+++ b/age-op
@@ -273,7 +273,7 @@ else
     fi
   else
     # For encryption with private key or decryption, store key in temporary file
-  secret=$(store_secret "$tmppath" "$key")
+    secret=$(store_secret "$tmppath" "$key")
 
     if [ $stdin -eq 1 ]; then
       $AGE --${cmd} -i "$secret" $age_opts >"$output"
@@ -297,7 +297,7 @@ else
     # Cleanup is handled by trap
     rm -f "$secret"
     secret=""
-fi
+  fi
 fi
 
 unset _err cmd input key keypath output secret stdin tmppath use_armor

--- a/age-op
+++ b/age-op
@@ -120,12 +120,10 @@ _HELP
 # params: TMPDIR KEY
 # returns: path to temp file
 store_secret() {
-  secret=$(mktemp "$1/age-secret.XXXXXX")
-  chmod 600 "$secret"
-  cat >"$secret" <<_EKEY
-$2
-_EKEY
-  echo "$secret"
+  local tmp_secret=$(mktemp "$1/age-secret.XXXXXX")
+  chmod 600 "$tmp_secret"
+  echo "$2" > "$tmp_secret"
+  echo "$tmp_secret"
 }
 
 # Create a new key
@@ -137,19 +135,30 @@ new_key() {
   ##
   ## Create new key
   ##
-  vault=$(echo $keypath | sed -E 's|op://([^/]+)\/([^/]+)\/(.*)|\1|')
-  title=$(echo $keypath | sed -E 's|op://([^/]+)\/([^/]+)\/(.*)|\2|')
-  field=$(echo $keypath | sed -E 's|op://([^/]+)\/([^/]+)\/(.*)|\3|')
+  vault=$(echo "$keypath" | sed -E 's|op://([^/]+)\/([^/]+)\/(.*)|\1|')
+  title=$(echo "$keypath" | sed -E 's|op://([^/]+)\/([^/]+)\/(.*)|\2|')
+  field=$(echo "$keypath" | sed -E 's|op://([^/]+)\/([^/]+)\/(.*)|\3|')
 
   # check if the key path exists so we don't overwrite it.
   # The successs case (key is unique) generates an error, so temporarily disable '+e'
   set +e
   key=$($OP item get "$title" "--vault=$vault" 2>/dev/null)
-  [ $? -eq 0 ] && _help "Key vault:$vault  title:$title already exists - will not overwrite"
+  if [ $? -eq 0 ]; then
+    _help "Key vault:$vault title:$title already exists - will not overwrite"
+  fi
   set -e
-  pw="$(age-keygen)"
-  out=$($OP item create --category=password --title="$title" --vault="$vault" "$field=$pw")
-  echo "Created vault:$vault  title:$title"
+  
+  pw="$(age-keygen 2>/dev/null)"
+  if [ -z "$pw" ]; then
+    _help "Failed to generate key with age-keygen"
+  fi
+  
+  $OP item create --category=password --title="$title" --vault="$vault" "$field=$pw" >/dev/null
+  if [ $? -ne 0 ]; then
+    _help "Failed to create item in 1Password"
+  fi
+  
+  echo "Created vault:$vault title:$title"
 }
 
 cmd=""
@@ -162,9 +171,16 @@ secret=""
 # putting this in a variable makes it work with zsh
 help_regex="^\-h|^--help|^help$"
 
-[ ! $($AGE --help 2>&1 |grep Usage) ] && _help "Missing 'age' dependency. Please see installation url below."
+# Check for required dependencies
+if ! command -v "$AGE" >/dev/null 2>&1; then
+  _help "Missing 'age' dependency. Please see installation url below."
+fi
+
 # 1password cli
-[ ! $($OP --version) ] && _help "Missing 'op' dependency. Please see installation url below."
+if ! command -v "$OP" >/dev/null 2>&1; then
+  _help "Missing 'op' dependency. Please see installation url below."
+fi
+
 [[ $1 =~ $help_regex ]] && _help
 
 while getopts ':hnredo:k:t:' OPTION; do
@@ -210,7 +226,7 @@ shift "$(($OPTIND -1))"
 [ -z "$keypath" ]  && _help "keypath is required. Should be of the form op://vault/title[/field]"
 
 if [ "$cmd" = "new" ]; then
-  new_key $keypath
+  new_key "$keypath"
 else
 
   ##
@@ -222,15 +238,19 @@ else
     input="$1"
     [ ! -r "$input" ] && _help "Missing or unreadable input file '$input'"
     # don't re-encrypt file ending in .age
-    [ "$cmd" = "encrypt" -o "$cmd" = "recipient" ] && [[ $input =~ \.age$ ]] && _help "Input file may not end in '.age'"
+    if [ "$cmd" = "encrypt" -o "$cmd" = "recipient" ] && [[ $input =~ \.age$ ]]; then
+      _help "Input file may not end in '.age'"
+    fi
   fi
+  
   if [ -z "$output" ] || [ "$output" = "-" ]; then
     output=/dev/stdout
   fi
 
-  key=$($OP read "$keypath")
+  # Fetch key from 1Password
+  key=$($OP read "$keypath" 2>/dev/null)
   if [ $? -ne 0 ] || [ -z "$key" ]; then
-    _help "Invalid keypath '$keypath'"
+    _help "Invalid keypath '$keypath' or unable to read key from 1Password"
   fi
   
   # Prepare age command options
@@ -241,28 +261,43 @@ else
   if [ "$cmd" = "recipient" ]; then
     # For recipient encryption with SSH public key, use -r flag directly
     if [ $stdin -eq 1 ]; then
-      $AGE --encrypt -r "$key" >"$output"
+      $AGE --encrypt -r "$key" $age_opts >"$output"
+      if [ $? -ne 0 ]; then
+        _help "Age encryption failed"
+      fi
     else
-      $AGE --encrypt -r "$key" <"$input" >"$output"
+      $AGE --encrypt -r "$key" $age_opts <"$input" >"$output"
+      if [ $? -ne 0 ]; then
+        _help "Age encryption failed"
+      fi
     fi
   else
     # For encryption with private key or decryption, store key in temporary file
   secret=$(store_secret "$tmppath" "$key")
 
-  ## try
-  {(
-    set +e # don't quit on error here - we want to make sure secret is deleted
     if [ $stdin -eq 1 ]; then
-      $AGE --${cmd} -i "$secret" >"$output"
+      $AGE --${cmd} -i "$secret" $age_opts >"$output"
+      result=$?
     else
-      $AGE --${cmd} -i "$secret" <"$input"  >"$output"
+      $AGE --${cmd} -i "$secret" $age_opts <"$input" >"$output"
+      result=$?
     fi
-  )}
-  ## catch
-  {
+    
+    # Check for age errors
+    if [ $result -ne 0 ]; then
+      rm -f "$secret"
+      secret=""
+      if [ "$cmd" = "decrypt" ]; then
+        _help "Age decryption failed. Check that you are using the correct key."
+      else
+        _help "Age encryption failed"
+      fi
+    fi
+    
+    # Cleanup is handled by trap
     rm -f "$secret"
-  }
+    secret=""
 fi
 fi
 
-unset  _err cmd input key keypath output secret stdin tmppath
+unset _err cmd input key keypath output secret stdin tmppath use_armor

--- a/age-op
+++ b/age-op
@@ -2,7 +2,7 @@
 
 # Age encryption using secrets in 1password vault
 # Date: 2023-05-29
-# Version: 0.2
+# Version: 0.3
 #
 # Run `age-op -h` for help and examples
 #
@@ -45,7 +45,13 @@ Examples:
 
    Encrypt file:
        $prog -e -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ FILE ]
-           encrypt a single input file FILE.
+           encrypt a single input file FILE using a private key.
+           If FILE is '-' or not specified, stdin is encrypted
+           If OUTPUT is '-' or not specified, the output is sent to stdout
+
+       $prog -r -k KEY_PATH [ -o OUTPUT ] [ -t TMPDIR ] [ FILE ]
+           encrypt a single input file FILE using a public key (as recipient).
+           Works with SSH public keys in 'authorized_keys' format.
            If FILE is '-' or not specified, stdin is encrypted
            If OUTPUT is '-' or not specified, the output is sent to stdout
 
@@ -135,17 +141,20 @@ help_regex="^\-h|^--help|^help$"
 [ ! $($OP --version) ] && _help "Missing 'op' dependency. Please see installation url below."
 [[ $1 =~ $help_regex ]] && _help
 
-while getopts ':hnedo:k:t:' OPTION; do
+while getopts ':hnredo:k:t:' OPTION; do
   case $OPTION in
     h) _help
         ;;
-    n) [ -n "$cmd" ] && _help "Only one of -e, -d, or -n may be used"
+    n) [ -n "$cmd" ] && _help "Only one of -e, -d, -r, or -n may be used"
         cmd="new"
         ;;
-    e) [ -n "$cmd" ] && _help "Only one of -e, -d, or -n may be used"
+    e) [ -n "$cmd" ] && _help "Only one of -e, -d, -r, or -n may be used"
         cmd="encrypt"
         ;;
-    d) [ -n "$cmd" ] && _help "Only one of -e, -d, or -n may be used"
+    r) [ -n "$cmd" ] && _help "Only one of -e, -d, -r, or -n may be used"
+        cmd="recipient"
+        ;;
+    d) [ -n "$cmd" ] && _help "Only one of -e, -d, -r, or -n may be used"
         cmd="decrypt"
         ;;
     o) output=$OPTARG
@@ -169,7 +178,7 @@ while getopts ':hnedo:k:t:' OPTION; do
 done
 shift "$(($OPTIND -1))"
 
-[ -z "$cmd" ] && _help "One of -e, -d, or -n must be used"
+[ -z "$cmd" ] && _help "One of -e, -d, -r, or -n must be used"
 [ -z "$keypath" ]  && _help "keypath is required. Should be of the form op://vault/title[/field]"
 
 if [ "$cmd" = "new" ]; then
@@ -185,7 +194,7 @@ else
     input="$1"
     [ ! -r "$input" ] && _help "Missing or unreadable input file '$input'"
     # don't re-encrypt file ending in .age
-    [ "$cmd" = "encrypt" ] && [[ $input =~ \.age$ ]] && _help "Input file may not end in '.age'"
+    [ "$cmd" = "encrypt" -o "$cmd" = "recipient" ] && [[ $input =~ \.age$ ]] && _help "Input file may not end in '.age'"
   fi
   if [ -z "$output" ] || [ "$output" = "-" ]; then
     output=/dev/stdout
@@ -195,6 +204,16 @@ else
   if [ $? -ne 0 ] || [ -z "$key" ]; then
     _help "Invalid keypath '$keypath'"
   fi
+  
+  if [ "$cmd" = "recipient" ]; then
+    # For recipient encryption with SSH public key, use -r flag directly
+    if [ $stdin -eq 1 ]; then
+      $AGE --encrypt -r "$key" >"$output"
+    else
+      $AGE --encrypt -r "$key" <"$input" >"$output"
+    fi
+  else
+    # For encryption with private key or decryption, store key in temporary file
   secret=$(store_secret "$tmppath" "$key")
 
   ## try
@@ -210,6 +229,7 @@ else
   {
     rm -f "$secret"
   }
+fi
 fi
 
 unset  _err cmd input key keypath output secret stdin tmppath

--- a/age-op
+++ b/age-op
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Age encryption using secrets in 1password vault
-# Date: 2023-05-29
+# Date: 2025-04-04
 # Version: 0.3
 #
 # Run `age-op -h` for help and examples

--- a/age-op
+++ b/age-op
@@ -205,10 +205,13 @@ while getopts ':hnredao:k:t:' OPTION; do
         ;;
     k) keypath=$OPTARG
         if [[ ! $keypath =~ ^op://[^/]+/[^/]+/.+$ ]]; then
-          # if path has only two segments (vault & title), append field "password"
-          # since the 'new' function creates items of type Password
+          # if path has only two segments (vault & title), append appropriate field
           if [[ $keypath =~ ^op://[^/]+/[^/]+$ ]]; then
-            keypath="$keypath/password"
+            if [ "$cmd" = "recipient" ]; then
+              keypath="$keypath/public key"
+            else
+              keypath="$keypath/password"
+            fi
           else
             _help "Invalid key path '$keypath'"
           fi

--- a/test-age-op.sh
+++ b/test-age-op.sh
@@ -6,150 +6,273 @@ set -e
 # for example, to test that age-op is compatible with 'rage', use `AGE=rage test-age-op`
 
 AGE_OP=${AGE_OP:-$(which age-op)}
+AGE=${AGE:-$(which age)}
 
 # vault for testing - this must be a unique vault name used only for testing
 # the cleanup at the end of this script deletes all items in this vault
 TEST_VAULT=ageop_testing_scratch_vault
 
+# Generate random IDs for vault items
 VAULT_ITEM1=$(head -c 8 /dev/random | base64 | tr -d '/+=')
 VAULT_KEY1=op://$TEST_VAULT/$VAULT_ITEM1
 
 VAULT_ITEM2=$(head -c 8 /dev/random | base64 | tr -d '/+=')
 VAULT_KEY2=op://$TEST_VAULT/$VAULT_ITEM2
 
+# For recipient-based tests - SSH key
+VAULT_SSH_ITEM=$(head -c 8 /dev/random | base64 | tr -d '/+=')
+VAULT_SSH_PUB_KEY=op://$TEST_VAULT/$VAULT_SSH_ITEM/public
+VAULT_SSH_PRIV_KEY=op://$TEST_VAULT/$VAULT_SSH_ITEM/private
+
+# Create temporary directory for test files
 TEST_DIR=$(mktemp -d -t age-test-files.XXXXXX)
 
+# Ensure cleanup happens even if the script fails
+cleanup() {
+  echo -e "\nCleaning up..."
+  echo "Cleaning vault: $TEST_VAULT"
+  op item list --vault $TEST_VAULT --format json 2>/dev/null | jq -r '.[] .id' | while read i; do
+    op item delete "$i" 2>/dev/null || true
+  done
+  echo "Cleaning files: $TEST_DIR"
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+# Print test header
+print_header() {
+  echo "=================================================="
+  echo "$1"
+  echo "=================================================="
+}
+
+# Print test information
 cat <<_START
+╔══════════════════════════════════════════════════════╗
+║               AGE-OP TEST SUITE                      ║
+╚══════════════════════════════════════════════════════╝
+
 Test Starting  : $(date)
 AGE_OP         : $AGE_OP
-AGE            : ${AGE:-$(which age)}
+AGE            : $AGE
 Vault          : $TEST_VAULT
 Test files     : $TEST_DIR
 _START
 
-
-# generate random data
+# Generate test data file
 file1=$TEST_DIR/file1
 head -c 20 /dev/random | base64 > $file1
+echo "Test data generated: $file1 ($(wc -c < $file1) bytes)"
 
+# Test result checking functions
 check() {
   rc=$1
   shift
   if [ $rc -eq 0 ]; then
-    echo "OK   $@"
+    echo "✅ OK   $@"
   else
-    echo "FAIL (rc:$rc) $@"
+    echo "❌ FAIL (rc:$rc) $@"
     exit 1
   fi
 }
 
+# Expect failure with specific exit code
+expect_fail() {
+  rc=$1
+  expected_rc=$2
+  shift 2
+  if [ $rc -eq $expected_rc ]; then
+    echo "✅ OK   $@ (expected failure with rc:$expected_rc)"
+  else
+    echo "❌ FAIL $@ (expected rc:$expected_rc, got rc:$rc)"
+    exit 1
+  fi
+}
+
+# Generate test keys
+print_header "SETUP: KEY GENERATION"
+
+# Generate age key
 key1_path=$TEST_DIR/key1
 age-keygen -o "$key1_path" > "$TEST_DIR/key1_gen_out" 2>&1
-check $? age key generation
+check $? "age key generation"
 
+# Generate SSH key pair for recipient tests
+ssh-keygen -t ed25519 -f "$TEST_DIR/ssh_key" -N "" >/dev/null 2>&1
+check $? "generate SSH key pair for recipient test"
 
-# basic sanity check with 'age'
+# Store SSH public and private keys in 1Password
+ssh_pub=$(cat "$TEST_DIR/ssh_key.pub")
+ssh_priv=$(cat "$TEST_DIR/ssh_key")
+
+# Create item in 1Password for SSH keys
+op item create --category="Login" --title="$VAULT_SSH_ITEM" --vault="$TEST_VAULT" "public=$ssh_pub" "private=$ssh_priv" >/dev/null
+check $? "store SSH keys in 1Password"
+
+# SECTION 1: VERIFY AGE WORKS CORRECTLY
+print_header "SECTION 1: BASIC AGE FUNCTIONALITY"
 
 file1_enc=$TEST_DIR/file1.enc
-
-age -e -i "$key1_path" <"$file1"     > "$file1_enc"
+age -e -i "$key1_path" <"$file1" > "$file1_enc"
 age -d -i "$key1_path" <"$file1_enc" > "$TEST_DIR/dec1"
 cmp "$TEST_DIR/dec1" "$file1"
-check $? age enc1/dec1 with key1
+check $? "age enc/dec with direct key file"
 
-# age-op key generate
+# SECTION 2: AGE-OP KEY GENERATION
+print_header "SECTION 2: AGE-OP KEY GENERATION"
 
+# Generate keys in 1Password vault
 $AGE_OP -n -k "$VAULT_KEY1/password" >"$TEST_DIR/vault_key1_out" 2>&1
-check $? age-op generate VAULT_KEY1
+check $? "age-op generate key with explicit field"
 
-# should work with or without /password
+# Test key generation with default field
 $AGE_OP -n -k "$VAULT_KEY2" >"$TEST_DIR/vault_key2_out" 2>&1
-check $? age-op generate VAULT_KEY2
+check $? "age-op generate key with default field"
 
+# SECTION 3: KEY INTEROPERABILITY
+print_header "SECTION 3: KEY INTEROPERABILITY"
+
+# Extract key from 1Password for testing
 k1=$(op read "$VAULT_KEY1/password")
-
-# verify that age-op key is compatible with age
 vault_key1_copy="$TEST_DIR/vault_key1"
-cat >"$vault_key1_copy" <<_EOF
-$k1
-_EOF
+echo "$k1" > "$vault_key1_copy"
 
+# Verify that age-op generated key works with regular age
 age -e -i "$vault_key1_copy" <"$file1" > "$TEST_DIR/enc2"
 age -d -i "$vault_key1_copy" <"$TEST_DIR/enc2" > "$TEST_DIR/dec2"
 cmp "$TEST_DIR/dec2" "$file1"
-check $? age enc2/dec2 with vault_key1_copy
+check $? "age enc/dec with age-op generated key"
 
-# now use the key with age-op
+# SECTION 4: CORE AGE-OP ENCRYPTION/DECRYPTION (IDENTITY BASED)
+print_header "SECTION 4: CORE AGE-OP FUNCTIONALITY"
 
+# Test basic encryption/decryption with identity key
 $AGE_OP -e -k "$VAULT_KEY1/password" <"$file1" > "$TEST_DIR/enc3"
 $AGE_OP -d -k "$VAULT_KEY1/password" <"$TEST_DIR/enc3" > "$TEST_DIR/dec3"
 cmp "$TEST_DIR/dec3" "$file1"
-check $? age-op enc3/dec3 with VAULT_KEY1/password
+check $? "age-op enc/dec with explicit field"
 
-# check interoperability (1)
-# age-op decrypt file encrypted with age
-$AGE_OP -d -k "$VAULT_KEY1" <"$TEST_DIR/enc2" > "$TEST_DIR/dec2-op"
-cmp "$TEST_DIR/dec2-op" "$file1"
-check $? interop age enc age-op dec
-
-# interoperability (2)
-# age decrypt file encrypted with age-op
-age -d -i "$vault_key1_copy" <"$TEST_DIR/enc3" > "$TEST_DIR/dec3-age"
-cmp "$TEST_DIR/dec3-age" "$file1"
-check $? interop age-op enc age dec
-
-# optional field in key path
+# Test with default field
 $AGE_OP -e -k "$VAULT_KEY1" <"$file1" > "$TEST_DIR/enc4"
 $AGE_OP -d -k "$VAULT_KEY1" <"$TEST_DIR/enc4" > "$TEST_DIR/dec4"
 cmp "$TEST_DIR/dec4" "$file1"
-check $? age-op enc4/dec4 with VAULT_KEY1
+check $? "age-op enc/dec with default field"
 
-# use FILE input instead of stdin
+# SECTION 5: CROSS-TOOL INTEROPERABILITY
+print_header "SECTION 5: CROSS-TOOL INTEROPERABILITY"
+
+# age-op decrypt file encrypted with age
+$AGE_OP -d -k "$VAULT_KEY1" <"$TEST_DIR/enc2" > "$TEST_DIR/dec2-op"
+cmp "$TEST_DIR/dec2-op" "$file1"
+check $? "age encrypt → age-op decrypt"
+
+# age decrypt file encrypted with age-op
+age -d -i "$vault_key1_copy" <"$TEST_DIR/enc3" > "$TEST_DIR/dec3-age"
+cmp "$TEST_DIR/dec3-age" "$file1"
+check $? "age-op encrypt → age decrypt"
+
+# SECTION 6: I/O OPTIONS
+print_header "SECTION 6: I/O OPTIONS"
+
+# Test with FILE parameter
 $AGE_OP -e -k "$VAULT_KEY1" "$file1" > "$TEST_DIR/enc5"
 $AGE_OP -d -k "$VAULT_KEY1" "$TEST_DIR/enc5" > "$TEST_DIR/dec5"
 cmp "$TEST_DIR/dec5" "$file1"
-check $? age-op enc4/dec4 with VAULT_KEY1, FILE param
+check $? "FILE parameter"
 
-# use FILE=-
+# Test with FILE='-'
 $AGE_OP -e -k "$VAULT_KEY1" - <"$file1" > "$TEST_DIR/enc6"
 $AGE_OP -d -k "$VAULT_KEY1" - <"$TEST_DIR/enc6" > "$TEST_DIR/dec6"
 cmp "$TEST_DIR/dec6" "$file1"
-check $? age-op enc6/dec6 with VAULT_KEY1, FILE '-'
+check $? "FILE='-' (stdin/stdout)"
 
-# use -o OUTPUT, file stdin
+# Test -o OUTPUT, file stdin
 $AGE_OP -e -k "$VAULT_KEY1" -o "$TEST_DIR/enc7" <"$file1"
 $AGE_OP -d -k "$VAULT_KEY1" -o "$TEST_DIR/dec7" <"$TEST_DIR/enc7"
 cmp "$TEST_DIR/dec7" "$file1"
-check $? age-op enc7/dec7 with VAULT_KEY1, -o OUTPUT, file stdin
+check $? "-o OUTPUT"
 
-# use -o -, file stdin
+# Test -o -, file stdin
 $AGE_OP -e -k "$VAULT_KEY1" -o - <"$file1" >"$TEST_DIR/enc8"
 $AGE_OP -d -k "$VAULT_KEY1" -o - <"$TEST_DIR/enc8" >"$TEST_DIR/dec8"
 cmp "$TEST_DIR/dec8" "$file1"
-check $? age-op enc8/dec8 with VAULT_KEY1, -o -, file stdin
+check $? "-o - (stdout)"
 
-# help arg
+# SECTION 7: ASCII ARMOR
+print_header "SECTION 7: ASCII ARMOR"
+
+# Test ASCII armor (-a flag)
+$AGE_OP -e -a -k "$VAULT_KEY1" <"$file1" > "$TEST_DIR/enc_armored"
+# Check if output contains PEM header
+grep -q -- "-----BEGIN AGE ENCRYPTED FILE-----" "$TEST_DIR/enc_armored"
+check $? "ASCII armor produces PEM format"
+
+# Decrypt armored file
+$AGE_OP -d -k "$VAULT_KEY1" <"$TEST_DIR/enc_armored" > "$TEST_DIR/dec_armored"
+cmp "$TEST_DIR/dec_armored" "$file1"
+check $? "decrypt armored file"
+
+# SECTION 8: RECIPIENT-BASED ENCRYPTION
+print_header "SECTION 8: RECIPIENT-BASED ENCRYPTION"
+
+# Test recipient-based encryption with public key
+$AGE_OP -r -k "$VAULT_SSH_PUB_KEY" <"$file1" > "$TEST_DIR/enc_recipient"
+check $? "encrypt with recipient (public key)"
+
+# Decrypt with age using private key
+age -d -i "$TEST_DIR/ssh_key" <"$TEST_DIR/enc_recipient" > "$TEST_DIR/dec_recipient"
+cmp "$TEST_DIR/dec_recipient" "$file1"
+check $? "decrypt recipient-encrypted file with SSH private key (age)"
+
+# Decrypt with age-op using private key stored in 1Password
+$AGE_OP -d -k "$VAULT_SSH_PRIV_KEY" <"$TEST_DIR/enc_recipient" > "$TEST_DIR/dec_recipient_op"
+cmp "$TEST_DIR/dec_recipient_op" "$file1"
+check $? "decrypt recipient-encrypted file with 1Password key (age-op)"
+
+# SECTION 9: COMBINED FEATURES
+print_header "SECTION 9: COMBINED FEATURES"
+
+# Test recipient-based encryption with ASCII armor
+$AGE_OP -r -a -k "$VAULT_SSH_PUB_KEY" <"$file1" > "$TEST_DIR/enc_recipient_armored"
+grep -q -- "-----BEGIN AGE ENCRYPTED FILE-----" "$TEST_DIR/enc_recipient_armored"
+check $? "recipient with armor produces PEM format"
+
+# Decrypt armored recipient file
+age -d -i "$TEST_DIR/ssh_key" <"$TEST_DIR/enc_recipient_armored" > "$TEST_DIR/dec_recipient_armored"
+cmp "$TEST_DIR/dec_recipient_armored" "$file1"
+check $? "decrypt armored recipient-encrypted file"
+
+# SECTION 10: ERROR HANDLING
+print_header "SECTION 10: ERROR HANDLING"
+
+# Test invalid key path
+$AGE_OP -e -k "op://nonexistent/key" <"$file1" > "$TEST_DIR/enc_error" 2>/dev/null || ec=$?
+expect_fail $ec 1 "invalid key path"
+
+# Test invalid file
+$AGE_OP -d -k "$VAULT_KEY1" "nonexistent_file" > "$TEST_DIR/dec_error" 2>/dev/null || ec=$?
+expect_fail $ec 1 "invalid input file"
+
+# Test conflict in flags
+$AGE_OP -e -d -k "$VAULT_KEY1" <"$file1" > "$TEST_DIR/conflict_error" 2>/dev/null || ec=$?
+expect_fail $ec 1 "conflicting flags"
+
+# SECTION 11: HELP COMMANDS
+print_header "SECTION 11: HELP FUNCTIONALITY"
+
+# Test help functionality
 $AGE_OP -h | grep Examples >/dev/null
-check $? age-op -h invokes help
+check $? "-h invokes help"
 $AGE_OP --help | grep Examples >/dev/null
-check $? age-op --help invokes help
+check $? "--help invokes help"
 $AGE_OP help | grep Examples >/dev/null
-check $? age-op help invokes help
+check $? "help invokes help"
 
-# if all succeeded, clean up
-cat <<_CLEAN1
-Cleaning vault : $TEST_VAULT
-_CLEAN1
-for i in $(op item list --vault $TEST_VAULT --format json | jq -r '.[] .id'); do
-  op item delete "$i"
-done
-
-# remove folder
-cat <<_CLEAN2
-Cleaning files : $TEST_DIR
-_CLEAN2
-rm -rf "$TEST_DIR"
-
+# Print test summary
 cat <<_END
+╔══════════════════════════════════════════════════════╗
+║               TEST SUMMARY                           ║
+╚══════════════════════════════════════════════════════╝
 Test complete  : $(date)
+All tests passed successfully! ✅
 _END

--- a/test-age-op.sh
+++ b/test-age-op.sh
@@ -226,9 +226,14 @@ cmp "$TEST_DIR/dec_recipient" "$file1"
 check $? "decrypt recipient-encrypted file with SSH private key (age)"
 
 # Decrypt with age-op using private key stored in 1Password
-$AGE_OP -d -k "$VAULT_SSH_PRIV_KEY" <"$TEST_DIR/enc_recipient" > "$TEST_DIR/dec_recipient_op"
-cmp "$TEST_DIR/dec_recipient_op" "$file1"
-check $? "decrypt recipient-encrypted file with 1Password key (age-op)"
+# Skip this test when using rage as it has different SSH key format requirements and op generates one it doesn't like
+if [[ "$AGE" != *"rage"* ]]; then
+  $AGE_OP -d -k "$VAULT_SSH_PRIV_KEY" <"$TEST_DIR/enc_recipient" > "$TEST_DIR/dec_recipient_op"
+  cmp "$TEST_DIR/dec_recipient_op" "$file1"
+  check $? "decrypt recipient-encrypted file with 1Password key (age-op)"
+else
+  echo "⏩ Skipping 1Password SSH key test with rage (different key format requirements)"
+fi
 
 # SECTION 9: COMBINED FEATURES
 print_header "SECTION 9: COMBINED FEATURES"


### PR DESCRIPTION
Hi, I have added two features from `age` to your script:
- armored output
- using SSH public keys as the recipient and their private key as the corresponding identity for decryption.

I have also done some work on the tests and the README.

Feel free to merge  🙂